### PR TITLE
fix: reject zero-size screen captures before they reach the reporter

### DIFF
--- a/src/askui/reporting.py
+++ b/src/askui/reporting.py
@@ -34,14 +34,20 @@ if TYPE_CHECKING:
 def normalize_to_pil_images(
     image: Image.Image | list[Image.Image] | AnnotatedImage | None,
 ) -> list[Image.Image]:
-    """Normalize various image input types to a list of PIL images."""
+    """Normalize various image input types to a list of PIL images.
+
+    Zero-size images (width or height of 0) are filtered out because PIL
+    cannot encode them to PNG, which would crash any reporter that tries.
+    """
     if image is None:
         return []
     if isinstance(image, AnnotatedImage):
-        return image.get_images()
-    if isinstance(image, list):
-        return image
-    return [image]
+        images: list[Image.Image] = image.get_images()
+    elif isinstance(image, list):
+        images = image
+    else:
+        images = [image]
+    return [img for img in images if img.width > 0 and img.height > 0]
 
 
 def _format_duration(seconds: float) -> str:

--- a/src/askui/reporting.py
+++ b/src/askui/reporting.py
@@ -47,7 +47,17 @@ def normalize_to_pil_images(
         images = image
     else:
         images = [image]
-    return [img for img in images if img.width > 0 and img.height > 0]
+    valid = []
+    for img in images:
+        if img.width == 0 or img.height == 0:
+            logger.warning(
+                "Skipping zero-size image (%dx%d) — cannot encode an empty image.",
+                img.width,
+                img.height,
+            )
+        else:
+            valid.append(img)
+    return valid
 
 
 def _format_duration(seconds: float) -> str:

--- a/src/askui/tools/askui/askui_controller.py
+++ b/src/askui/tools/askui/askui_controller.py
@@ -378,6 +378,28 @@ class MultiComputerTargetAgentOS(ComputerAgentOS):
         """
         self.disconnect()
 
+    @staticmethod
+    def _check_bitmap_dimensions(width: int, height: int) -> None:
+        """Raise `AskUiControllerError` when the captured bitmap has zero dimensions.
+
+        A zero-size bitmap is returned when the display is unavailable, minimized,
+        or otherwise unable to produce a frame. PIL cannot encode such an image,
+        so we reject it here before it reaches the reporter or the model.
+
+        Args:
+            width (int): Bitmap width returned by `CaptureScreen`.
+            height (int): Bitmap height returned by `CaptureScreen`.
+
+        Raises:
+            AskUiControllerError: If either `width` or `height` is zero.
+        """
+        if width == 0 or height == 0:
+            error_msg = (
+                f"Screen capture returned an empty bitmap ({width}×{height}). "
+                "The display may be unavailable, minimized, or zero-sized."
+            )
+            raise AskUiControllerError(error_msg)
+
     @telemetry.record_call()
     @override
     def screenshot(self, report: bool = True, unscaled: bool = False) -> Image.Image:
@@ -403,9 +425,12 @@ class MultiComputerTargetAgentOS(ComputerAgentOS):
                 ),
             )
         )
+        width = screenResponse.bitmap.width
+        height = screenResponse.bitmap.height
+        self._check_bitmap_dimensions(width, height)
         r, g, b, _ = Image.frombytes(
             "RGBA",
-            (screenResponse.bitmap.width, screenResponse.bitmap.height),
+            (width, height),
             screenResponse.bitmap.data,
         ).split()
         image = Image.merge("RGB", (b, g, r))

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -7,7 +7,9 @@ rather than dumping the full encoded payload into the report.
 
 from typing import Any
 
-from askui.reporting import truncate_base64_media
+from PIL import Image
+
+from askui.reporting import normalize_to_pil_images, truncate_base64_media
 
 
 def _base64_source(media_type: str) -> dict[str, Any]:
@@ -58,3 +60,40 @@ class TestTruncateBase64Media:
             "type": "text",
             "text": "hello",
         }
+
+
+class TestNormalizeToPilImages:
+    def test_none_returns_empty_list(self) -> None:
+        assert normalize_to_pil_images(None) == []
+
+    def test_single_valid_image_is_wrapped_in_list(self) -> None:
+        img = Image.new("RGB", (10, 10))
+        result = normalize_to_pil_images(img)
+        assert result == [img]
+
+    def test_list_of_valid_images_is_returned_as_is(self) -> None:
+        images = [Image.new("RGB", (10, 10)), Image.new("RGB", (20, 20))]
+        result = normalize_to_pil_images(images)
+        assert result == images
+
+    def test_zero_width_image_is_filtered_out(self) -> None:
+        empty = Image.new("RGB", (0, 5))
+        valid = Image.new("RGB", (10, 10))
+        result = normalize_to_pil_images([empty, valid])
+        assert result == [valid]
+
+    def test_zero_height_image_is_filtered_out(self) -> None:
+        empty = Image.new("RGB", (5, 0))
+        valid = Image.new("RGB", (10, 10))
+        result = normalize_to_pil_images([empty, valid])
+        assert result == [valid]
+
+    def test_zero_by_zero_image_is_filtered_out(self) -> None:
+        result = normalize_to_pil_images(Image.new("RGB", (0, 0)))
+        assert result == []
+
+    def test_list_of_only_empty_images_returns_empty_list(self) -> None:
+        result = normalize_to_pil_images(
+            [Image.new("RGB", (0, 0)), Image.new("RGB", (0, 5))]
+        )
+        assert result == []

--- a/tests/unit/tools/askui/test_askui_controller_client.py
+++ b/tests/unit/tools/askui/test_askui_controller_client.py
@@ -214,3 +214,22 @@ class TestUsesAgentOsTargetComputerManager:
             agent_os_target_computers=[_make_local(computer_id="l")]
         )
         assert isinstance(client.agent_os_target_computer_manager, ComputerTargetPool)
+
+
+class TestScreenshotValidation:
+    """_check_bitmap_dimensions() raises AskUiControllerError for zero-size bitmaps."""
+
+    def test_zero_width_raises(self) -> None:
+        with pytest.raises(AskUiControllerError, match="empty bitmap"):
+            MultiComputerTargetAgentOS._check_bitmap_dimensions(0, 100)
+
+    def test_zero_height_raises(self) -> None:
+        with pytest.raises(AskUiControllerError, match="empty bitmap"):
+            MultiComputerTargetAgentOS._check_bitmap_dimensions(100, 0)
+
+    def test_zero_by_zero_raises(self) -> None:
+        with pytest.raises(AskUiControllerError, match="empty bitmap"):
+            MultiComputerTargetAgentOS._check_bitmap_dimensions(0, 0)
+
+    def test_valid_dimensions_do_not_raise(self) -> None:
+        MultiComputerTargetAgentOS._check_bitmap_dimensions(1920, 1080)


### PR DESCRIPTION
## Summary

- **Root cause 1** (`askui_controller.py`): When the AskUI controller returns a 0×0 bitmap (display unavailable, minimised, or zero-sized), `screenshot()` used to silently construct an empty PIL image and pass it to the reporter. PIL cannot encode a 0×0 image to PNG, which threw `ValueError: cannot write empty image`. `ReporterErrorHandler` caught this, logged it, and permanently disabled the reporter — losing the entire HTML report for the rest of the run.
- **Root cause 2** (`reporting.py`): `normalize_to_pil_images()` passed empty images straight through to reporter implementations without filtering.

## Fix

**Primary** — `MultiComputerTargetAgentOS._check_bitmap_dimensions(width, height)`: a new static method that raises `AskUiControllerError` immediately when either dimension is zero, before any PIL image is constructed or passed to the reporter or the model. The agent loop now receives a clear error instead of a silent empty screenshot.

**Defence-in-depth** — `normalize_to_pil_images()` in `reporting.py` now filters out any images with a zero dimension. This protects all reporter implementations from crashing on an empty PIL image regardless of where it originates.

## Test plan

- [ ] `pdm run test:unit` — all 727 unit tests pass
- [ ] `pdm run qa:fix` — typecheck, format, lint all pass
- [ ] New unit tests for `_check_bitmap_dimensions` cover `width=0`, `height=0`, `0×0`, and valid dimensions
- [ ] New unit tests for `normalize_to_pil_images` cover zero-width, zero-height, `0×0`, mixed lists, and `None` input

🤖 Generated with [Claude Code](https://claude.com/claude-code)