### PR TITLE
fix: split Desktop Agent OS errors into recoverable vs unfixable

### DIFF
--- a/src/askui/tools/askui/askui_controller.py
+++ b/src/askui/tools/askui/askui_controller.py
@@ -28,6 +28,7 @@ from askui.tools.askui.agent_os_target_computer import (
 )
 from askui.tools.askui.askui_ui_controller_grpc.desktop_agent_os_error import (
     DesktopAgentOsError,
+    DesktopAgentOsException,
 )
 from askui.tools.askui.askui_ui_controller_grpc.generated import (
     Controller_V1_pb2 as controller_v1_pbs,
@@ -1442,7 +1443,7 @@ class MultiComputerTargetAgentOS(ComputerAgentOS):
             message = f"unexpected response type: {res}"
             raise DesktopAgentOsError(message)
         if res.error is not None:
-            raise DesktopAgentOsError(res.error)
+            raise DesktopAgentOsException(res.error)
         if res.response is None:
             message = f"{type(res).__name__} is missing both error and response"
             raise DesktopAgentOsError(message)
@@ -1472,7 +1473,10 @@ class MultiComputerTargetAgentOS(ComputerAgentOS):
             Image.Image | PdfSource | str: The decoded file contents.
 
         Raises:
-            DesktopAgentOsError: If the file cannot be read or the response is invalid.
+            DesktopAgentOsException: If the file cannot be read (e.g. the path
+                does not exist or its contents cannot be decoded).
+            DesktopAgentOsError: If the controller response violates the expected
+                protocol.
         """
         self._reporter.add_message(self._REPORTER_SOURCE, f"get_file({path})")
         command = GetFileCommand(parameters=[path])
@@ -1481,7 +1485,7 @@ class MultiComputerTargetAgentOS(ComputerAgentOS):
             message = f"unexpected response type: {res}"
             raise DesktopAgentOsError(message)
         if res.error is not None:
-            raise DesktopAgentOsError(res.error)
+            raise DesktopAgentOsException(res.error)
         if res.response is None:
             message = f"{type(res).__name__} is missing both error and response"
             raise DesktopAgentOsError(message)
@@ -1535,7 +1539,7 @@ class MultiComputerTargetAgentOS(ComputerAgentOS):
             except UnicodeDecodeError:
                 pass
         message = "File contents are neither a supported image, PDF, nor UTF-8 text"
-        raise DesktopAgentOsError(message)
+        raise DesktopAgentOsException(message)
 
 
 AskUiControllerClient = MultiComputerTargetAgentOS

--- a/src/askui/tools/askui/askui_ui_controller_grpc/desktop_agent_os_error.py
+++ b/src/askui/tools/askui/askui_ui_controller_grpc/desktop_agent_os_error.py
@@ -1,5 +1,30 @@
-class DesktopAgentOsError(BaseException):
-    """Base class for Desktop Agent OS errors.
+from askui.models.exceptions import AutomationError
 
-    This error is raised when an error occurs in the Desktop Agent OS.
+
+class DesktopAgentOsError(AutomationError):
+    """Unfixable error raised by the Desktop Agent OS.
+
+    Raised when the Desktop Agent OS returns a response that violates the
+    expected protocol (e.g. an unexpected response type or a response missing
+    both an error and a payload). These indicate a broken controller or
+    connection rather than something the agent can recover from, so - like
+    other `AutomationError`s - they are re-raised by the tool-calling loop and
+    terminate the run.
+
+    For failures the agent can react to and work around (e.g. a path that does
+    not exist), raise `DesktopAgentOsException` instead.
+    """
+
+
+class DesktopAgentOsException(Exception):  # noqa: N818
+    """Recoverable error raised by the Desktop Agent OS.
+
+    Raised when an operation on the Desktop Agent OS fails in a way the agent
+    can react to and work around - for example, reading a file or directory
+    that does not exist, or a file whose contents cannot be decoded. Because it
+    derives from `Exception` (and not `AutomationError`), the tool-calling loop
+    catches it and surfaces it to the agent as a tool error result instead of
+    terminating the run.
+
+    For unfixable protocol violations, raise `DesktopAgentOsError` instead.
     """

--- a/tests/unit/models/shared/test_desktop_agent_os_error_handling.py
+++ b/tests/unit/models/shared/test_desktop_agent_os_error_handling.py
@@ -1,0 +1,77 @@
+"""Tests that Desktop Agent OS errors are routed by recoverability.
+
+The Desktop Agent OS raises two error types:
+
+- `DesktopAgentOsException` for failures the agent can react to (e.g. reading a
+  path that does not exist). The tool-calling loop catches it and surfaces it to
+  the agent as a tool error result so the run can continue.
+- `DesktopAgentOsError` for unfixable protocol violations. It derives from
+  `AutomationError` and is re-raised by the tool-calling loop, terminating the
+  run instead of being fed back to the agent.
+"""
+
+import pytest
+
+from askui.models.exceptions import AutomationError
+from askui.models.shared.agent_message_param import (
+    ToolResultBlockParam,
+    ToolUseBlockParam,
+)
+from askui.models.shared.tools import Tool, ToolCollection
+from askui.tools.askui.askui_ui_controller_grpc.desktop_agent_os_error import (
+    DesktopAgentOsError,
+    DesktopAgentOsException,
+)
+
+_RECOVERABLE_MESSAGE = (
+    "directory_iterator::directory_iterator: The system cannot find the "
+    'path specified.: "FrontEnd\\Traces"'
+)
+_FATAL_MESSAGE = "unexpected response type: <broken>"
+
+
+class _RaisingTool(Tool):
+    """A tool whose `__call__` raises the exception it was constructed with."""
+
+    _error: BaseException
+
+    def __init__(self, error: BaseException) -> None:
+        super().__init__(
+            name="raising_tool",
+            description="Raises a preconfigured Desktop Agent OS error.",
+        )
+        self._error = error
+
+    def __call__(self) -> str:
+        raise self._error
+
+
+def _run(tool: Tool) -> list:
+    collection = ToolCollection(tools=[tool])
+    tool_use = ToolUseBlockParam(id="tool_use_1", input={}, name=tool.name)
+    return collection.run([tool_use])
+
+
+class TestDesktopAgentOsErrorHierarchy:
+    def test_error_is_an_automation_error(self) -> None:
+        assert issubclass(DesktopAgentOsError, AutomationError)
+
+    def test_exception_is_a_plain_exception_not_automation_error(self) -> None:
+        assert issubclass(DesktopAgentOsException, Exception)
+        assert not issubclass(DesktopAgentOsException, AutomationError)
+
+
+class TestDesktopAgentOsErrorHandling:
+    def test_recoverable_exception_returns_error_result(self) -> None:
+        results = _run(_RaisingTool(DesktopAgentOsException(_RECOVERABLE_MESSAGE)))
+
+        assert len(results) == 1
+        result = results[0]
+        assert isinstance(result, ToolResultBlockParam)
+        assert result.is_error is True
+        assert result.tool_use_id == "tool_use_1"
+        assert "FrontEnd\\Traces" in str(result.content)
+
+    def test_fatal_error_propagates_and_terminates(self) -> None:
+        with pytest.raises(DesktopAgentOsError):
+            _run(_RaisingTool(DesktopAgentOsError(_FATAL_MESSAGE)))

--- a/tests/unit/tools/askui/test_decode_file_payload.py
+++ b/tests/unit/tools/askui/test_decode_file_payload.py
@@ -14,7 +14,7 @@ from PIL import Image
 
 from askui.tools.askui.askui_controller import (
     AskUiControllerClient,
-    DesktopAgentOsError,
+    DesktopAgentOsException,
 )
 from askui.utils.pdf_utils import PdfSource
 
@@ -47,5 +47,5 @@ class TestDecodeFilePayload:
         assert result == "hello world"
 
     def test_rejects_unsupported_binary(self) -> None:
-        with pytest.raises(DesktopAgentOsError):
+        with pytest.raises(DesktopAgentOsException):
             AskUiControllerClient._decode_file_payload(_b64(b"\x00\x01\x02\x03"))


### PR DESCRIPTION
## Problem

When a tool that talks to the Desktop Agent OS fails — for example, reading a remote file or listing a directory that does not exist — the whole agent run crashed with an unhandled error, instead of the failure being reported back to the agent as a tool error (the way other tool failures are handled).

The reason: the Desktop Agent OS error type inherited from `BaseException`. The tool-calling loop catches tool failures with `except Exception` and converts them into an error result the agent can react to, but `except Exception` does not catch `BaseException` subclasses, so the error slipped past and propagated all the way up.

## Approach

Rather than simply reparenting the single error type (see the discussion on the previous attempt), this splits Desktop Agent OS errors into two types, matching how the codebase already distinguishes fatal from recoverable errors in the tool-calling loop:

- **`DesktopAgentOsException` (recoverable)** — a plain `Exception` for failures the agent can react to and work around (e.g. a path that does not exist, or file contents that cannot be decoded). The loop's generic `except Exception` catches it and surfaces it to the agent as a tool error result, so the run continues.
- **`DesktopAgentOsError` (unfixable)** — now inherits from `AutomationError`, for protocol violations (unexpected response type, a response missing both an error and a payload). The loop's existing `except (AgentError, AutomationError): raise` re-raises it, terminating the run cleanly instead of crashing on an uncaught `BaseException`.

Controller-reported operation failures and undecodable payloads now raise the recoverable type; contract/protocol violations keep the fatal type. **No changes to the generic tool-calling loop are required** — both types plug into the existing fatal/recoverable handling.

`DesktopAgentOsError` subclasses `AutomationError` (from `models/exceptions.py`) rather than `AgentError`; the latter would introduce a circular import, while the former is cycle-safe.

## Testing

- Added a regression test that drives both error types through the tool-calling loop: the recoverable one returns an `is_error=True` tool result, the fatal one propagates.
- Updated the existing decode test to expect the recoverable type for undecodable file contents.
- `pdm run qa:fix` passes (typecheck, format, lint); affected unit suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)