### PR TITLE
fix(models): request visible thinking summaries on adaptive-thinking models

### DIFF
--- a/src/askui/models/shared/thinking.py
+++ b/src/askui/models/shared/thinking.py
@@ -159,10 +159,17 @@ def make_thinking_settings(
             **make_thinking_settings(self._vlm_provider.model_id),
         )
 
-    Models that support adaptive thinking get ``thinking={"type": "adaptive"}``
-    (with ``effort`` sent via ``provider_options["output_config"]`` when given);
-    older models get a fixed token budget of
-    ``thinking={"type": "enabled", "budget_tokens": 2048}`` and ignore ``effort``.
+    Models that support adaptive thinking get
+    ``thinking={"type": "adaptive", "display": "summarized"}`` (with ``effort``
+    sent via ``provider_options["output_config"]`` when given); older models
+    get a fixed token budget of
+    ``thinking={"type": "enabled", "budget_tokens": 2048}`` and ignore
+    ``effort``. ``display`` is set explicitly because the newest adaptive
+    models (Sonnet 5 generation onward) default it to ``"omitted"``, which
+    returns thinking blocks whose text is EMPTY while the full thinking
+    tokens are still billed — reasoning silently disappears from reports and
+    logs. ``"summarized"`` restores the visible text at no extra cost (billing
+    is identical for both display modes).
 
     Args:
         model_id (str): The model identifier (bare or gateway-prefixed).
@@ -176,7 +183,9 @@ def make_thinking_settings(
             when applicable, ``provider_options``).
     """
     if uses_adaptive_thinking(model_id):
-        settings: dict[str, Any] = {"thinking": {"type": "adaptive"}}
+        settings: dict[str, Any] = {
+            "thinking": {"type": "adaptive", "display": "summarized"}
+        }
         if effort is not None:
             settings["provider_options"] = {"output_config": {"effort": effort}}
         return settings

--- a/tests/unit/models/test_thinking.py
+++ b/tests/unit/models/test_thinking.py
@@ -50,7 +50,9 @@ _BUDGET_MODELS = [
 @pytest.mark.parametrize("model_id", _ADAPTIVE_MODELS)
 def test_adaptive_models_use_adaptive_thinking(model_id: str) -> None:
     assert uses_adaptive_thinking(model_id) is True
-    assert make_thinking_settings(model_id) == {"thinking": {"type": "adaptive"}}
+    assert make_thinking_settings(model_id) == {
+        "thinking": {"type": "adaptive", "display": "summarized"}
+    }
 
 
 @pytest.mark.parametrize("model_id", _BUDGET_MODELS)
@@ -63,7 +65,7 @@ def test_other_models_use_budget_tokens(model_id: str) -> None:
 
 def test_effort_is_added_via_provider_options_for_adaptive_models() -> None:
     assert make_thinking_settings("claude-sonnet-5", effort="high") == {
-        "thinking": {"type": "adaptive"},
+        "thinking": {"type": "adaptive", "display": "summarized"},
         "provider_options": {"output_config": {"effort": "high"}},
     }
 
@@ -139,6 +141,6 @@ def test_non_thinking_settings_omit_thinking_on_always_on_models() -> None:
 
 def test_effort_supports_xhigh() -> None:
     assert make_thinking_settings("claude-opus-4-8", effort="xhigh") == {
-        "thinking": {"type": "adaptive"},
+        "thinking": {"type": "adaptive", "display": "summarized"},
         "provider_options": {"output_config": {"effort": "xhigh"}},
     }


### PR DESCRIPTION
## Why

Models of the Sonnet 5 generation onward default the thinking `display` setting to **"omitted"**: the API returns thinking blocks whose text is empty (signature only), while the full thinking tokens are still billed (`usage.output_tokens_details.thinking_tokens`). Every consumer of `make_thinking_settings()` therefore silently loses all visible reasoning in reports and logs on the newest models — bitten in production by the TCPos test-automation project, where HTML reports showed 175/175 empty thinking blocks.

Older adaptive models (Sonnet 4.6 / Opus 4.6) default `display` to summarized, which is why the gap only appears from Sonnet 5 onward.

## What

`make_thinking_settings()` now returns `thinking={"type": "adaptive", "display": "summarized"}` for adaptive models. Billing is identical for both display modes ([docs](https://platform.claude.com/docs/en/build-with-claude/thinking-steering-and-cost#pricing)) — this only restores visibility. The legacy `budget_tokens` branch is unchanged.

## Verification

- `pytest tests/unit/models/test_thinking.py` — 54 passed (assertions updated)
- `ruff check` / `ruff format --check` clean on changed files
- Live end-to-end against Vertex `claude-sonnet-5` (`rawPredict`, eu + global endpoints): empty thinking text before, 3,162 chars of summarized thinking after — with identical `thinking_tokens` billed

## Notes

Same follow-up as #302: the C# SDK carries a port of this module — mirroring PR opened in askui/csharp-sdk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)