### PR TITLE
docs: clarify get_file_names_tool returns files only, not folders

### DIFF
--- a/src/askui/tools/store/computer/experimental/get_file_names.py
+++ b/src/askui/tools/store/computer/experimental/get_file_names.py
@@ -28,9 +28,11 @@ class ComputerGetFileNamesTool(ComputerBaseTool):
             name="get_file_names_tool",
             description=(
                 "Lists the names of regular files in an absolute directory on the "
-                "computer under automation. Subdirectories are not included—only "
-                "files are returned. Use absolute paths as on the target machine. "
-                "Returns names only; use get_file_tool to read a file's contents."
+                "computer under automation. IMPORTANT: only files are returned - "
+                "folders and subdirectories are NOT included in the result and this "
+                "tool cannot be used to discover or navigate them. Use absolute "
+                "paths as on the target machine. Returns names only; use "
+                "get_file_tool to read a file's contents."
             ),
             input_schema={
                 "type": "object",


### PR DESCRIPTION
## What

Adjusts the tool description of `ComputerGetFileNamesTool` (`get_file_names_tool`) to make it explicit that the tool returns **only files** and does **not** include folders/subdirectories in its result.

## Why

The previous wording mentioned subdirectories were not included, but it was easy for the agent to overlook. This makes it unambiguous that the tool cannot be used to discover or navigate directories, so the agent doesn't attempt to list folders with it.

### Before
> Lists the names of regular files in an absolute directory on the computer under automation. Subdirectories are not included—only files are returned. Use absolute paths as on the target machine. Returns names only; use get_file_tool to read a file's contents.

### After
> Lists the names of regular files in an absolute directory on the computer under automation. IMPORTANT: only files are returned - folders and subdirectories are NOT included in the result and this tool cannot be used to discover or navigate them. Use absolute paths as on the target machine. Returns names only; use get_file_tool to read a file's contents.

Description-only change; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)