### PR TITLE
fix(deps): cap anthropic to <1 to prevent temperature-kwarg crash

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "all", "bedrock", "dev", "office-document", "otel", "vertex", "web"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:156da503bb3b6d055b873aca6b997b6e62cb1b42bf9ccb17ade899bb0d8c6052"
+content_hash = "sha256:45cd1d1a4c6c7b2a02b08ccd9938cdd7fa6637f509e498ff80e0e887da89111a"
 
 [[metadata.targets]]
 requires_python = ">=3.10,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 dependencies = [
     "askui-agent-os>=26.6.1",
-    "anthropic>=0.86.0",
+    "anthropic>=0.86.0,<1",  # <1: 1.x dropped the `temperature` kwarg the SDK still sends, crashing every model call
     "fastapi>=0.115.12",
     "fastmcp>=2.3.0",
     "gradio-client>=1.4.3",
@@ -213,7 +213,7 @@ office-document = [
     "markitdown[xls,xlsx,docx]>=0.1.2"
 ]
 bedrock = [
-    "anthropic[bedrock]>=0.72.0"
+    "anthropic[bedrock]>=0.72.0,<1"
 ]
 otel = [
     "opentelemetry-api>=1.38.0",
@@ -222,7 +222,7 @@ otel = [
 ]
 vertex = [
     "google-cloud-aiplatform>=1.122.0",
-    "anthropic[vertex]>=0.72.0",
+    "anthropic[vertex]>=0.72.0,<1",
 ]
 web = [
     "playwright>=1.41.0",


### PR DESCRIPTION
## Problem

`anthropic` **1.x** removed the `temperature` parameter from `beta.messages.create`. The SDK still passes `temperature` on every model call (as the `omit` sentinel when the user sets none), so **any install that resolves `anthropic >= 1.0` crashes on the first model request**:

```
TypeError: Messages.create() got an unexpected keyword argument 'temperature'
```

This happens **regardless of whether the user ever sets a temperature** — the SDK forwards the keyword unconditionally. Because our dependency was unbounded (`anthropic>=0.86.0`), a fresh install pulls the latest `anthropic` (1.2.0), and the whole agent is dead on the first call.

## Fix

Cap the `anthropic` dependency — and the `bedrock` / `vertex` extras — to `<1`:

```
anthropic>=0.86.0,<1
anthropic[bedrock]>=0.72.0,<1
anthropic[vertex]>=0.72.0,<1
```

The lock stays on the known-good, already-tested **0.116.0** (only the lock's `content_hash` changes — no other packages move).

## Scope

This PR does **nothing except the pin** — no code changes. It's an immediate, low-risk stopgap so users stop pulling the incompatible client.

A separate PR (#312) makes the code compatible with `anthropic` 1.x (routes `temperature` through `extra_body` and gates it by model/thinking capability). Once that lands, this `<1` cap can be relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)